### PR TITLE
Update README to match `ReasonUrql` namespacing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,30 @@
 # reason-urql
-ReasonML bindings for Formidable's Universal React Query Library (URQL) https://github.com/FormidableLabs/urql
+
+ReasonML bindings for Formidable's Universal React Query Library (`urql`) https://github.com/FormidableLabs/urql
 
 > Warning: These bindings are in a WiP state. Do not use in production (yet) 😉.
 
+## Table of Contents
+
+- [What is `reason-urql`?](#what-is-reason-urql?)
+- [Run the Example Project](#run-the-example-project)
+- [Installation](#installation)
+- [Building `reason-urql`](#building-reason-urql)
+- [API](#api)
+  - [`Client`](#client)
+  - [`Provider`](#provider)
+  - [`Connect`](#connect)
+
+## What is `reason-urql`?
+
+`urql` is a GraphQL client for React, allowing you to hook up your components to queries, mutations, and subscriptions. `reason-urql` provides bindings to `urql` that allow you to use the API in Reason. We are working hard to support the full API – check back regularly for updates.
+
 ## Run the Example Project
+
 The example project is a simple app for viewing and liking Formidable dogs. To get the example running locally:
 
 ```sh
-# in one terminal, start the server
+# in one terminal, start the GraphQL server
 yarn run start-demo-server
 
 # in another terminal, start webpack for the app
@@ -17,17 +34,14 @@ yarn run start-demo-app
 open example/app/index.html
 ```
 
-You should now be able to edit the example freely, and refresh the page to see changes take effect.
+You should now be able to edit the example freely, and refresh the page to see changes take effect. We're working on getting hot reloading into the example soon!
 
 ## Installation
-These bindings have not yet been published to `npm`. For now, clone locally:
 
-```sh
-git clone
-yarn
-```
+These bindings have not yet been published to `npm`. Check back soon for updates!
 
 ## Bulding `reason-urql`
+
 To build a production version of `reason-urql`:
 
 ```sh
@@ -39,13 +53,14 @@ This will replace `build/Index.js` with an optimized build.
 
 ## API
 
-### Client
-**Before reading this section, read the docs on `urql`'s native JS [`Client` API](https://github.com/FormidableLabs/urql#client)** 
+### `Client`
 
-`urql`'s `Client` API takes a config object containing values for `url`, `cache`, `initialCache`, and `fetchOptions`. We model this config as a `[@bs.deriving abstract]`, BuckleScript's implementation for JavaScript objects: https://bucklescript.github.io/docs/en/object#record-mode. Note that using `[@bs.deriving abstract]` gives us both a `type` for `urqlClientConfig` and a function for generating the config object (also called `urqlClientConfig`). To create a new `Client` in `reason-urql`, first create the config:
+**Before reading this section, read the docs on `urql`'s [`Client` API](https://github.com/FormidableLabs/urql#client).**
+
+`urql`'s `Client` API takes a config object containing values for `url`, `cache`, `initialCache`, and `fetchOptions`. We model this config as a `[@bs.deriving abstract]`, BuckleScript's [implementation for JavaScript objects](https://bucklescript.github.io/docs/en/object#record-mode). Note that using `[@bs.deriving abstract]` gives us both a `type` for `urqlClientConfig` and a function for generating the config object (also called `urqlClientConfig`). To create a new `Client` in `reason-urql`, first create the config:
 
 ```re
-let config: Client.urqlClientConfig(Js.t({.})) = Client.urqlClientConfig(~url="https://myapi.com", ());
+let config: ReasonUrql.Client.urqlClientConfig(Js.t({.})) = ReasonUrql.Client.urqlClientConfig(~url="https://myapi.com", ());
 ```
 
 The type argument passed to `Client.urqlClientConfig` allows you to specify the structure of your `fetchOptions` argument. This argument can be either an object or a function that returns an object. In Reason, we model this using a polymorphic variant:
@@ -60,16 +75,16 @@ fetchOptions: [
 To pass something like a custom header to your `fetch` calls, for example, you'd do the following:
 
 ```re
-/* Define the type matching the structure of your `fetchOptions` */
+/* Define the type matching the structure of your `fetchOptions`. */
 type fetchOptions = {.
   "custom-header": string
 }
 
-/* Use the polymorphic variant `FetchObj to mark `fetchOptions` as a plain object */
+/* Use the polymorphic variant `FetchObj to mark `fetchOptions` as a plain object. */
 let fetchOptions = `FetchObj({. "custom-header": "my-custom-header" });
 
-/* We can take advantage of Reason punning to pass `fetchOptions` implictly */
-let config: Client.urqlClientConfig(fetchOptions) = Client.urqlClientConfig(~url="https://myapi.com", ~fetchOptions, ());
+/* We can take advantage of Reason punning to pass `fetchOptions` implictly. */
+let config: ReasonUrql.Client.urqlClientConfig(fetchOptions) = ReasonUrql.Client.urqlClientConfig(~url="https://myapi.com", ~fetchOptions, ());
 ```
 
 This allows you to get type safety for your `fetchOptions` argument. The compiler will also alert you if you alter the shape of `fetchOptions` without updating the type appropriately.
@@ -77,13 +92,13 @@ This allows you to get type safety for your `fetchOptions` argument. The compile
 Now that we have a config, creating the `Client` is easy:
 
 ```re
-let client = Client.client(config);
+let client = ReasonUrql.Client.client(config);
 ```
 
 Once the `Client` is instantiated, we get access to its methods `executeQuery` and `executeMutation`. Since these APIs are `Promise`-based on the JS side of things, you'll need to use [Reason's `Promise` syntax](https://reasonml.github.io/docs/en/promise) to use them. For example:
 
 ```
-let exampleQuery = Query.urqlQuery(
+let exampleQuery = ReasonUrql.Query.urqlQuery(
   ~query={|
     query {
       dogs {
@@ -105,12 +120,17 @@ Client.executeQuery(client, exampleQuery, false)
 ```
 
 #### Remaining Todos
-We are still working on ways to support properly typed custom `cache` implementations. PRs welcome!
+
+PRs welcome!
+
+- [] Support properly typed custom `cache` implementations. Tracked in [#6](https://github.com/parkerziegler/reason-urql/issues/6).
+- [] Potentially require type parameters to properly type the results of `executeQuery` and `executeMutation` rather than leaving them abstract.
 
 ### Provider
-**Before reading this section, read the docs on `urql`'s native JS [`Provider` API](https://github.com/FormidableLabs/urql#provider).**
 
-To support the `Provider` component in ReasonReact, we take advantage of ReasonReact's excellent [`wrapJSForReason` helper](https://reasonml.github.io/reason-react/docs/en/interop#reasonreact-using-reactjs). `Provider` accepts a single `prop`, `client`. `client` accepts an instance of `Client.urqlClient` (see previous section). For example:
+**Before reading this section, read the docs on `urql`'s [`Provider` API](https://github.com/FormidableLabs/urql#provider).**
+
+To support the `Provider` component in ReasonReact, we take advantage of ReasonReact's excellent [`wrapJSForReason` helper](https://reasonml.github.io/reason-react/docs/en/interop#reasonreact-using-reactjs). `Provider` accepts a single `prop`, `client`. `client` accepts an instance of `ReasonUrql.Client.client` (see previous section). For example:
 
 ```
 /* After instantiating our client (see above), we can wrap our app in the `Provider` component */
@@ -118,12 +138,13 @@ let component = ReasonReact.statelessComponent("App");
 
 let make = _children => {
   ...component,
-  render: _self => <Provider client> <Header /> <Layout /> </Provider>,
+  render: _self => <ReasonUrql.Provider client> <Header /> <Layout /> </ReasonUrql.Provider>,
 };
 ```
 
 ### Connect
-**Before reading this section, read the docs on `urql`'s native JS [`Connect` API](https://github.com/FormidableLabs/urql#connect).**
+
+**Before reading this section, read the docs on `urql`'s [`Connect` API](https://github.com/FormidableLabs/urql#connect).**
 
 Once you've wrapped your app in the `Provider` component, you can use `urql`'s `Connect` component to wire up UI to queries, mutations, and your cache. `Connect` uses the [render prop](https://reactjs.org/docs/render-props.html) pattern.
 
@@ -136,7 +157,7 @@ type renderArgs('data) = {
   fetching: bool,
   loaded: bool,
   data: 'data,
-  error,
+  error: Js.Nullable.t(error),
   refetch,
   refreshAllFromCache
 };
@@ -146,7 +167,7 @@ To use the `Connect` component in Reason to execute a simple query and render UI
 
 ```re
 /* Define a GraphQL query with urql's query API (see below) */
-let exampleQuery = Query.urqlQuery(
+let exampleQuery = ReasonUrql.Query.urqlQuery(
   ~query={|
     query {
       dogs {
@@ -178,13 +199,13 @@ type dogs = {
 /* An example make function for a ReasonReact component */
 let make = (_children) => {
   ...component,
-  render: _ => <Connect
+  render: _ => <ReasonUrql.Connect
     query={`Query(exampleQuery)}
-    renderProp={(result: Connect.renderArgs(dogs)) => {
+    renderProp={(result: ReasonUrql.Connect.renderArgs(dogs)) => {
 
       /* We can use the fast pipe operator to access entries like `loaded`.
       This is due to the fact that `renderArgs` is a [@bs.deriving abstract]. */
-      let loaded = result |. Connect.loaded;
+      let loaded = result |. ReasonUrql.Connect.loaded;
 
       /* Now we can pattern match on the loaded variable and render UI. */
       switch (loaded) {
@@ -199,7 +220,7 @@ let make = (_children) => {
                 breed={dog |. breed}
                 description={dog |. description}
               />
-            }, result |. Connect.data |. dogs)
+            }, result |. ReasonUrql.Connect.data |. dogs)
             |> ReasonReact.array
           )</div>
         }
@@ -209,21 +230,24 @@ let make = (_children) => {
 }
 ```
 
-Awesome! We get the power of `Connect`'s render prop convention to connect our UI to a GraphQL query, all while maintaining type saftey with Reason 🚀. 
+Awesome! We get the power of `Connect`'s render prop convention to connect our UI to a GraphQL query, all while maintaining type saftey with Reason 🚀.
 
 #### Mutation
+
 `urql` does a pretty nifty thing to support mutations on the `Connect` component. It takes a user-supplied `mutation` map and turns each mutation into a function accessible on the object passed to `Connect`'s render prop. It accomplishes this through props spreading, [a technique that Reason does not support](https://reasonml.github.io/reason-react/docs/en/props-spread). Props spreading can be modeled easily on the TypeScript side using intersection types. It gets a bit trickier to model this behavior on the Reason end while still maintaining robust type safety. We can't intersect a set of known types (the render prop argument) with unknown, user-supplied types (mutations) behind the scenes – only the user can know what they need and how it's typed.
 
 To alleviate some of this difficulty, we use BuckleScript's [`JS.Dict` API](https://bucklescript.github.io/docs/en/object#hash-map-mode) to model the `mutation` prop.
+
 ```re
-/* Mutation.urqlMutation is just `urql`'s Mutation API (see below) */
-type mutationMap = Js.Dict.t(Mutation.urqlMutation);
+/* ReasonUrql.Mutation.urqlMutation is just `urql`'s Mutation API (see below) */
+type mutationMap = Js.Dict.t(ReasonUrql.Mutation.urqlMutation);
 ```
 
 To set up a mutation map, you'd do something like the following:
+
 ```re
 /* Define a GraphQL mutation. */
-let likeDog: Mutation.urqlMutation = Mutation.mutation(
+let likeDog: ReasonUrql.Mutation.urqlMutation = ReasonUrql.Mutation.mutation(
   ~query={|
     mutation likeDog($key: ID!) {
       likeDog(key: $key) {
@@ -241,7 +265,7 @@ let mutationMap = Js.Dict.empty();
 Js.Dict.set(mutationMap, "likeDog", likeDog);
 
 /* On your Connect component, pass it as the mutation prop. */
-<Connect mutation={mutationMap} />
+<ReasonUrql.Connect mutation={mutationMap} />
 ```
 
 Then, to use the mutation in your component, you'll need to let `Connect` know that it is an available field on the render prop object argument. To do this, use `[@bs.send]`.
@@ -252,6 +276,7 @@ Then, to use the mutation in your component, you'll need to let `Connect` know t
 ```
 
 Then, to use it in your component:
+
 ```re
 let make = (_children) => {
   ...component,
@@ -290,6 +315,7 @@ let make = (_children) => {
 Ultimately, the use of `[@bs.send]` here is a workaround to support a proper binding of `urql`'s API and appropriate compilation by the BuckleScript compiler. It maintains type safety by allowing the user to specify the exact shape of each `mutation` they pass to `Connect`.
 
 ### Query
+
 **Before reading this section, read the docs on `urql`'s native JS [`Query` API](https://github.com/FormidableLabs/urql#query).**
 
 Binding to `urql`'s `query` API is fairly simple. The JS implementation is just a function that accepts a `query` string argument (your GraphQL query) and, optionally, a `variables` argument and returns an object of the shape:
@@ -342,6 +368,7 @@ let exampleQuery: Query.urqlQuery = Query.query(
 We currently _don't_ typecheck the `variables` argument – the binding accepts a type parameter that allows `variables` to be of whatever type the user provided argument is. This may change in upcoming versions of `reason-urql`.
 
 ### Mutation
+
 **Before reading this section, read the docs on `urql`'s native JS [`Mutation` API](https://github.com/FormidableLabs/urql#mutation).**
 
 The bindings for `reason-urql`'s `mutation` API is very similar to that of `query`. Just call the `mutation` function from the `Mutation` module.

--- a/example/app/App.re
+++ b/example/app/App.re
@@ -1,9 +1,11 @@
+open ReasonUrql;
+
 /* Setup the config for the client. */
-let config: ReasonUrql.Client.urqlClientConfig({.}) =
-  ReasonUrql.Client.urqlClientConfig(~url="http://localhost:3001", ());
+let config: Client.urqlClientConfig({.}) =
+  Client.urqlClientConfig(~url="http://localhost:3001", ());
 
 /* Instantiate the client instance. */
-let client = ReasonUrql.Client.client(config);
+let client = Client.client(config);
 
 /* Now, let's render a child component attached to a query. First, wrap
    the component in <Provider />. */
@@ -12,5 +14,5 @@ let component = ReasonReact.statelessComponent("App");
 let make = _children => {
   ...component,
   render: _self =>
-    <ReasonUrql.Provider client> <Header /> <DogList /> </ReasonUrql.Provider>,
+    <Provider client> <Header /> <DogList /> </Provider>,
 };

--- a/example/app/App.re
+++ b/example/app/App.re
@@ -1,6 +1,3 @@
-/* let read = (~query) => Js.Promise.make((~resolve, ~reject as _) => resolve(. { "blah": 2 }));
-   let write = (~query, ~data) => Js.Promise.make((~resolve, ~reject as _) => resolve(. 4));
-   let cache: Client.urqlCache = Client.urqlCache(~read=read, ~write=write); */
 /* Setup the config for the client. */
 let config: ReasonUrql.Client.urqlClientConfig({.}) =
   ReasonUrql.Client.urqlClientConfig(~url="http://localhost:3001", ());

--- a/example/app/DogList.re
+++ b/example/app/DogList.re
@@ -1,7 +1,9 @@
+open ReasonUrql;
+
 let component = ReasonReact.statelessComponent("DogList");
 
-let query: ReasonUrql.Query.urqlQuery =
-  ReasonUrql.Query.query(
+let query: Query.urqlQuery =
+  Query.query(
     ~query=
       {|
     query {
@@ -18,8 +20,8 @@ let query: ReasonUrql.Query.urqlQuery =
     (),
   );
 
-let likeDog: ReasonUrql.Mutation.urqlMutation =
-  ReasonUrql.Mutation.mutation(
+let likeDog: Mutation.urqlMutation =
+  Mutation.mutation(
     ~query=
       {|
     mutation likeDog($key: ID!) {
@@ -34,7 +36,7 @@ let likeDog: ReasonUrql.Mutation.urqlMutation =
     (),
   );
 
-let mutationMap: ReasonUrql.Connect.mutationMap = Js.Dict.empty();
+let mutationMap: Connect.mutationMap = Js.Dict.empty();
 
 Js.Dict.set(mutationMap, "likeDog", likeDog);
 
@@ -52,22 +54,22 @@ type dogs = {dogs: array(dog)};
 
 [@bs.send]
 external likeDog :
-  (ReasonUrql.Connect.renderArgs(dogs), {. "key": string}) => unit =
+  (Connect.renderArgs(dogs), {. "key": string}) => unit =
   "";
 
 let make = _children => {
   ...component,
   render: _self =>
-    <ReasonUrql.Connect
+    <Connect
       query=(`Query(query))
       mutation=mutationMap
       renderProp=(
-        (~result: ReasonUrql.Connect.renderArgs(dogs)) => {
-          let loaded = result |. ReasonUrql.Connect.loaded;
-          let data = result |. ReasonUrql.Connect.data;
+        (~result: Connect.renderArgs(dogs)) => {
+          let loaded = result |. Connect.loaded;
+          let data = result |. Connect.data;
           let error =
-            ReasonUrql.Connect.convertJsErrorToReason(
-              result |. ReasonUrql.Connect.error,
+            Connect.convertJsErrorToReason(
+              result |. Connect.error,
             );
           switch (error) {
           | Some(obj) =>
@@ -86,7 +88,7 @@ let make = _children => {
               )>
               (
                 ReasonReact.string(
-                  "Error: " ++ (obj |. ReasonUrql.Connect.message),
+                  "Error: " ++ (obj |. Connect.message),
                 )
               )
             </div>
@@ -105,11 +107,10 @@ let make = _children => {
                 (
                   Array.map(
                     dog => {
-                      let key = dog |. key;
                       <Dog
-                        key={j|$key|j}
+                        key=(dog |. key)
                         description=(dog |. description)
-                        id=key
+                        id=(dog |. key)
                         imageUrl=(dog |. imageUrl)
                         name=(dog |. name)
                         likes=(dog |. likes)

--- a/example/app/Example.re
+++ b/example/app/Example.re
@@ -1,6 +1,8 @@
+open ReasonUrql;
+
 /* Let's start by executing a simple query. */
-let query: ReasonUrql.Query.urqlQuery =
-  ReasonUrql.Query.query(
+let query: Query.urqlQuery =
+  Query.query(
     ~query={j|
 query {
   dogs {
@@ -18,15 +20,15 @@ type fetchOptions = {. "formidable": int};
 let fetchOptions = {"formidable": 1};
 
 /* Create our client config. */
-let config: ReasonUrql.Client.urqlClientConfig(fetchOptions) =
-  ReasonUrql.Client.urqlClientConfig(
+let config: Client.urqlClientConfig(fetchOptions) =
+  Client.urqlClientConfig(
     ~url="http://localhost:3001",
     ~fetchOptions=`FetchObj(fetchOptions),
     (),
   );
 
 /* Instantiate the client instance. */
-let client = ReasonUrql.Client.client(config);
+let client = Client.client(config);
 
 /* Cool, let's render the App now! */
 ReactDOMRe.renderToElementWithId(<App />, "root");

--- a/example/app/Header.re
+++ b/example/app/Header.re
@@ -1,7 +1,9 @@
+open ReasonUrql;
+
 let component = ReasonReact.statelessComponent("Header");
 
-let likeAllDogs: ReasonUrql.Mutation.urqlMutation =
-  ReasonUrql.Mutation.mutation(
+let likeAllDogs: Mutation.urqlMutation =
+  Mutation.mutation(
     ~query=
       {|
     mutation likeAllDogs {
@@ -14,20 +16,20 @@ let likeAllDogs: ReasonUrql.Mutation.urqlMutation =
     (),
   );
 
-let mutationMap: ReasonUrql.Connect.mutationMap = Js.Dict.empty();
+let mutationMap: Connect.mutationMap = Js.Dict.empty();
 
 Js.Dict.set(mutationMap, "likeAllDogs", likeAllDogs);
 
 [@bs.send]
-external likeAllDogs : (ReasonUrql.Connect.renderArgs({.}), unit) => unit = "";
+external likeAllDogs : (Connect.renderArgs({.}), unit) => unit = "";
 
 let make = _children => {
   ...component,
   render: _self =>
-    <ReasonUrql.Connect
+    <Connect
       mutation=mutationMap
       renderProp=(
-        (~result: ReasonUrql.Connect.renderArgs({.})) =>
+        (~result: Connect.renderArgs({.})) =>
           <header
             style=(
               ReactDOMRe.Style.make(


### PR DESCRIPTION
This PR addresses #3. Now that we have successfully namespaced the module under `ReasonUrql`, the docs are updated to reflect that change. This PR also adds the convention of using a global `open` on `ReasonUrql` in the example, which makes accessing it's `module`s a little friendly (less verbose) syntax-wise.