### PR TITLE
Add `bs.fetch` for properly typed `fetchOptions`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 /node_modules/
 *.bs.js
 example/build/
+/.graphql_ppx_cache/

--- a/README.md
+++ b/README.md
@@ -70,12 +70,16 @@ This will replace `build/Index.js` with an optimized build.
 `urql`'s `Client` API takes a config object containing values for `url`, `cache`, `initialCache`, and `fetchOptions`. We model this config as a `[@bs.deriving abstract]`, BuckleScript's [implementation for JavaScript objects](https://bucklescript.github.io/docs/en/object#record-mode). To create a new `Client` using `reason-urql`, simply call the `make` function from the `Client` module:
 
 ```reason
+open ReasonUrql;
+
 let client = Client.make(~url="https://myapi.com/graphql", ());
 ```
 
-In order to pass `fetchOptions` to your `Client`, you'll need to create them using the `Fetch.RequestInit.make()` function from [`bs-fetch`](https://github.com/reasonml-community/bs-fetch). Using this function gives guaranteed safety that the options you are passing to `urql`'s `fetch` calls are semantically correct and type safe. To set this up with `reason-urql`, do something like the following:
+In order to pass `fetchOptions` to your `Client`, you'll need to create them using the `Fetch.RequestInit.make()` function from [`bs-fetch`](https://github.com/reasonml-community/bs-fetch). Using this function guarantees that the options you are passing to `urql`'s `fetch` calls are valid and type safe. To set this up with `reason-urql`, do something like the following:
 
 ```reason
+open ReasonUrql;
+
 let makeFetchOptions =
   Fetch.RequestInit.make(
     ~method_=Post,
@@ -83,14 +87,13 @@ let makeFetchOptions =
     (),
   );
 
-/* Wrap your fetchOptions in the fetchOptions variant, which accepts either
-Cient.FetchObj or Client.FetchFn */
+/* Wrap your fetchOptions in the fetchOptions variant, which accepts the Cient.FetchObj or Client.FetchFn constructor. */
 let fetchOptions = Client.FetchObj(makeFetchOptions);
 
 let client = Client.make(~url="http://localhost:3001", ~fetchOptions, ());
 ```
 
-In `urql`, your `fetchOptions` argument can either be an object or a function returning an object: `RequestInit | () => RequestInit`. We use variants to model this in Reason.
+In `urql`, your `fetchOptions` argument can either be an object or a function returning an object: `RequestInit | () => RequestInit`. We use variants to model this in `reason-urql`.
 
 ```reason
 type fetchOptions =

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Reason bindings for Formidable's Universal React Query Library (`urql`) https://
     - [`Remaining Todos`](#remaining-todos)
   - [`Provider`](#provider)
   - [`Connect`](#connect)
-    - [`Handling Errors`](#handling-errors)
-    - [`Mutations and Connect`](#mutations-and-connect)
+    - [Handling Errors](#handling-errors)
+    - [Mutations and `Connect`](#mutations-and-connect)
   - [`Query`](#query)
   - [`Mutation`](#mutation)
-- [`Getting Involved`](#getting-involved)
+- [Getting Involved](#getting-involved)
 
 ## What is `reason-urql`?
 
@@ -33,11 +33,14 @@ The example project is a simple app for viewing and liking Formidable dogs. To g
 # in one terminal, start the GraphQL server
 yarn start-demo-server
 
-# in another terminal, build the example and start webpack for the app
-yarn build
+# in a second terminal, compile the app in watch mode
+yarn start
+
+# in another terminal, start webpack for the app
 yarn start-demo-app
 
-# then, in a third terminal
+# open up the app either by clicking the index.html file in your file browser
+# or calling it from the command line
 open example/app/index.html
 ```
 
@@ -64,84 +67,82 @@ This will replace `build/Index.js` with an optimized build.
 
 **Before reading this section, read the docs on `urql`'s [`Client` API](https://github.com/FormidableLabs/urql#client).**
 
-`urql`'s `Client` API takes a config object containing values for `url`, `cache`, `initialCache`, and `fetchOptions`. We model this config as a `[@bs.deriving abstract]`, BuckleScript's [implementation for JavaScript objects](https://bucklescript.github.io/docs/en/object#record-mode). Note that using `[@bs.deriving abstract]` gives us both a `type` for `urqlClientConfig` and a function for generating the config object (also called `urqlClientConfig`). To create a new `Client` in `reason-urql`, first create the config:
+`urql`'s `Client` API takes a config object containing values for `url`, `cache`, `initialCache`, and `fetchOptions`. We model this config as a `[@bs.deriving abstract]`, BuckleScript's [implementation for JavaScript objects](https://bucklescript.github.io/docs/en/object#record-mode). To create a new `Client` using `reason-urql`, simply call the `make` function from the `Client` module:
+
+```reason
+let client = Client.make(~url="https://myapi.com/graphql", ());
+```
+
+In order to pass `fetchOptions` to your `Client`, you'll need to create them using the `Fetch.RequestInit.make()` function from [`bs-fetch`](https://github.com/reasonml-community/bs-fetch). Using this function gives guaranteed safety that the options you are passing to `urql`'s `fetch` calls are semantically correct and type safe. To set this up with `reason-urql`, do something like the following:
+
+```reason
+let makeFetchOptions =
+  Fetch.RequestInit.make(
+    ~method_=Post,
+    ~headers=Fetch.HeadersInit.make({"Content-Type": "application/json"}),
+    (),
+  );
+
+/* Wrap your fetchOptions in the fetchOptions variant, which accepts either
+Cient.FetchObj or Client.FetchFn */
+let fetchOptions = Client.FetchObj(makeFetchOptions);
+
+let client = Client.make(~url="http://localhost:3001", ~fetchOptions, ());
+```
+
+In `urql`, your `fetchOptions` argument can either be an object or a function returning an object: `RequestInit | () => RequestInit`. We use variants to model this in Reason.
+
+```reason
+type fetchOptions =
+  | FetchObj(Fetch.requestInit)
+  | FetchFn(unit => Fetch.requestInit);
+```
+
+Once the `Client` is instantiated, you get access to its methods `executeQuery` and `executeMutation`. Since these APIs are `Promise`-based on the JS side of things, you'll need to use [Reason's `Promise` syntax](https://reasonml.github.io/docs/en/promise) to use them. For example:
 
 ```reason
 open ReasonUrql;
 
-let config: Client.urqlClientConfig({.}) = Client.urqlClientConfig(~url="https://myapi.com", ());
+let query =
+  Query.query(
+    ~query={|
+query dogs {
+  dogs {
+    name
+    breed
+    description
+  }
+}
+|},
+    (),
+  );
+
+let client = Client.make(~url="http://localhost:3001", ());
+
+Client.executeQuery(~client, ~query, ~skipCache=false)
+|> Js.Promise.then_(value => {
+     let dogs = value##data##dogs;
+     Js.log(dogs);
+     Js.Promise.resolve(dogs);
+   })
+|> Js.Promise.catch(err => {
+     Js.log2("Something went wrong!", err);
+     Js.Promise.resolve(err);
+   });
 ```
 
-The type argument passed to `Client.urqlClientConfig` allows you to specify the structure of your `fetchOptions` argument. This argument can be either an object or a function that returns an object. In Reason, we model this using a polymorphic variant:
+#### Current API
 
-```reason
-fetchOptions: [
-  | `FetchObj('fetchOptions)
-  | `FetchFunc(unit => 'fetchOptions)
-]
-```
-
-To pass something like a custom header to your `fetch` calls, for example, you'd do the following:
-
-```reason
-open ReasonUrql;
-
-/* Define the type matching the structure of your `fetchOptions`. */
-type fetchOptions = {.
-  "X-Reason-App": string
-};
-
-/* Use the polymorphic variant `FetchObj to mark `fetchOptions` as a plain object. */
-let fetchOptions = `FetchObj({. "X-Reason-App": "my-custom-header" });
-
-/* We can take advantage of Reason punning to pass `fetchOptions` implictly. */
-let config: Client.urqlClientConfig(fetchOptions) = Client.urqlClientConfig(~url="https://myapi.com", ~fetchOptions, ());
-```
-
-This allows you to get type safety for your `fetchOptions` argument. The compiler will also alert you if you alter the shape of `fetchOptions` without updating the type appropriately.
-
-Now that we have a config, creating the `Client` is easy:
-
-```reason
-open ReasonUrql;
-
-let client = Client.client(config);
-```
-
-Once the `Client` is instantiated, we get access to its methods `executeQuery` and `executeMutation`. Since these APIs are `Promise`-based on the JS side of things, you'll need to use [Reason's `Promise` syntax](https://reasonml.github.io/docs/en/promise) to use them. For example:
-
-```reason
-open ReasonUrql;
-
-let exampleQuery = Query.query(
-  ~query={|
-    query {
-      dogs {
-        key
-        name
-        breed
-        description
-      }
-    }
-  |},
-  ()
-);
-
-Client.executeQuery(client, exampleQuery, false)
-|>  Js.Promise.then_(value => {
-    let dogs = value##data##dogs;
-    Js.log(dogs);
-    Js.Promise.resolve(dogs);
-});
-```
+| Name              | Type                                                                             | Description                               |
+| ----------------- | -------------------------------------------------------------------------------- | ----------------------------------------- |
+| `make`            | (~url: string, ~?fetchOptions: option(fetchOptions), unit)                       | Creates an `urql` Client.                 |
+| `executeQuery`    | (~client: client, ~query: Query.urqlQuery, ~skipCache: bool) => Js.Promise.t('a) | Executes a `query` using the `client`.    |
+| `executeMutation` | (~client: client, ~mutation: Mutation.urqlMutation) => Js.Promise.t('a)          | Executes a `mutation` using the `client`. |
 
 #### Remaining Todos
 
-- [ ] Support properly typed custom `cache` implementations. Tracked in [#6](https://github.com/parkerziegler/reason-urql/issues/6).
-- [ ] Potentially require type parameters to properly type the results of `executeQuery` and `executeMutation` rather than leaving them abstract.
 - [ ] Add `graphql_ppx` for proper GraphQL schema validation. Tracked in [#5](https://github.com/parkerziegler/reason-urql/issues/5).
-
-PRs are encouraged! Thanks for helping out!
+- [ ] Support properly typed custom `cache` implementations. Tracked in [#6](https://github.com/parkerziegler/reason-urql/issues/6).
 
 ### Provider
 

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,7 +1,3 @@
-/* This is the BuckleScript configuration file. Note that this is a comment;
-  BuckleScript comes with a JSON parser that supports comments and trailing
-  comma. If this screws with your editor highlighting, please tell us by filing
-  an issue! */
 {
   "name": "react-template",
   "reason": {
@@ -9,23 +5,23 @@
   },
   "sources": [
     {
-      "dir" : "src",
-      "subdirs" : true
+      "dir": "src",
+      "subdirs": true
     },
     {
       "dir": "example",
       "subdirs": true
     }
   ],
-  "package-specs": [{
-    "module": "commonjs",
-    "in-source": true
-  }],
+  "package-specs": [
+    {
+      "module": "commonjs",
+      "in-source": true
+    }
+  ],
   "suffix": ".bs.js",
   "namespace": true,
-  "bs-dependencies": [
-    "reason-react"
-  ],
+  "bs-dependencies": ["reason-react", "bs-fetch"],
   "refmt": 3,
   "warnings": {
     "error": "+5"

--- a/example/app/App.re
+++ b/example/app/App.re
@@ -1,18 +1,10 @@
 open ReasonUrql;
 
-/* Setup the config for the client. */
-let config: Client.urqlClientConfig({.}) =
-  Client.urqlClientConfig(~url="http://localhost:3001", ());
-
-/* Instantiate the client instance. */
-let client = Client.client(config);
-
 /* Now, let's render a child component attached to a query. First, wrap
    the component in <Provider />. */
 let component = ReasonReact.statelessComponent("App");
 
-let make = _children => {
+let make = (~client: Client.client, _children) => {
   ...component,
-  render: _self =>
-    <Provider client> <Header /> <DogList /> </Provider>,
+  render: _self => <Provider client> <Header /> <DogList /> </Provider>,
 };

--- a/example/app/DogList.re
+++ b/example/app/DogList.re
@@ -6,7 +6,7 @@ let query: Query.urqlQuery =
   Query.query(
     ~query=
       {|
-    query {
+    query dogs {
       dogs {
         name
         key
@@ -53,8 +53,7 @@ type dog = {
 type dogs = {dogs: array(dog)};
 
 [@bs.send]
-external likeDog :
-  (Connect.renderArgs(dogs), {. "key": string}) => unit =
+external likeDog : (Connect.renderArgs(dogs), {. "key": string}) => unit =
   "";
 
 let make = _children => {
@@ -67,10 +66,7 @@ let make = _children => {
         (~result: Connect.renderArgs(dogs)) => {
           let loaded = result |. Connect.loaded;
           let data = result |. Connect.data;
-          let error =
-            Connect.convertJsErrorToReason(
-              result |. Connect.error,
-            );
+          let error = Connect.convertJsErrorToReason(result |. Connect.error);
           switch (error) {
           | Some(obj) =>
             <div
@@ -86,11 +82,7 @@ let make = _children => {
                   (),
                 )
               )>
-              (
-                ReasonReact.string(
-                  "Error: " ++ (obj |. Connect.message),
-                )
-              )
+              (ReasonReact.string("Error: " ++ (obj |. Connect.message)))
             </div>
           | None =>
             switch (loaded) {
@@ -106,7 +98,7 @@ let make = _children => {
                 )>
                 (
                   Array.map(
-                    dog => {
+                    dog =>
                       <Dog
                         key=(dog |. key)
                         description=(dog |. description)
@@ -115,8 +107,7 @@ let make = _children => {
                         name=(dog |. name)
                         likes=(dog |. likes)
                         onClick=(result |. likeDog)
-                      />;
-                    },
+                      />,
                     data |. dogs,
                   )
                   |> ReasonReact.array

--- a/example/app/Example.re
+++ b/example/app/Example.re
@@ -3,32 +3,41 @@ open ReasonUrql;
 /* Let's start by executing a simple query. */
 let query: Query.urqlQuery =
   Query.query(
-    ~query={j|
-query {
+    ~query=
+      {|
+query dogs {
   dogs {
     name
     breed
     description
   }
 }
-|j},
+|},
     (),
   );
 
-type fetchOptions = {. "formidable": int};
-
-let fetchOptions = {"formidable": 1};
-
-/* Create our client config. */
-let config: Client.urqlClientConfig(fetchOptions) =
-  Client.urqlClientConfig(
-    ~url="http://localhost:3001",
-    ~fetchOptions=`FetchObj(fetchOptions),
+let makeFetchOptions =
+  Fetch.RequestInit.make(
+    ~method_=Post,
+    ~headers=Fetch.HeadersInit.make({"Content-Type": "application/json"}),
     (),
   );
+
+let fetchOptions = Client.FetchObj(makeFetchOptions);
 
 /* Instantiate the client instance. */
-let client = Client.client(config);
+let client = Client.make(~url="http://localhost:3001", ~fetchOptions, ());
+
+Client.executeQuery(~client, ~query, ~skipCache=false)
+|> Js.Promise.then_(value => {
+     let dogs = value##data##dogs;
+     Js.log(dogs);
+     Js.Promise.resolve(dogs);
+   })
+|> Js.Promise.catch(err => {
+     Js.log2("Something went wrong!", err);
+     Js.Promise.resolve(err);
+   });
 
 /* Cool, let's render the App now! */
-ReactDOMRe.renderToElementWithId(<App />, "root");
+ReactDOMRe.renderToElementWithId(<App client />, "root");

--- a/example/app/Header.re
+++ b/example/app/Header.re
@@ -20,8 +20,7 @@ let mutationMap: Connect.mutationMap = Js.Dict.empty();
 
 Js.Dict.set(mutationMap, "likeAllDogs", likeAllDogs);
 
-[@bs.send]
-external likeAllDogs : (Connect.renderArgs({.}), unit) => unit = "";
+[@bs.send] external likeAllDogs : (Connect.renderArgs({.}), unit) => unit = "";
 
 let make = _children => {
   ...component,

--- a/example/server/index.js
+++ b/example/server/index.js
@@ -1,27 +1,45 @@
-const graphqlHttp = require('express-graphql');
-const express = require('express');
+"use strict";
+
+const graphqlHttp = require("express-graphql");
+const express = require("express");
 const app = express();
-const cors = require('cors');
+const cors = require("cors");
+const fetch = require("isomorphic-fetch");
+require("es6-promise").polyfill();
 
-app.use(cors());
+const start = async () => {
+  // make the req to RawGit for Formidable dogs
+  const res = await fetch(
+    "https://rawgit.com/FormidableLabs/dogs/master/dogs.json"
+  );
 
-const { schema, context } = require('./schema');
+  const data = await res.json();
+  const dogs = data.map(dog => ({
+    ...dog,
+    likes: 0
+  }));
 
-const PORT = 3001;
+  app.use(cors());
 
-const initializedGraphQLMiddleware = graphqlHttp({
-  // GraphQL’s data schema
-  schema: schema,
-  // Pretty Print the JSON response
-  pretty: true,
-  // Enable GraphiQL dev tool
-  graphiql: true,
-  // A function that returns extra data available to every resolver
-  context: context,
-});
+  const { schema } = require("./schema");
 
-app.use(initializedGraphQLMiddleware);
+  const PORT = 3001;
 
-app.listen(PORT, () => {
-  console.log(`Server running at http://localhost:${PORT}`);
-});
+  const initializedGraphQLMiddleware = graphqlHttp({
+    // GraphQL’s data schema
+    schema: schema(dogs),
+    // Pretty Print the JSON response
+    pretty: true,
+    // Enable GraphiQL dev tool
+    graphiql: true
+  });
+
+  app.use(initializedGraphQLMiddleware);
+
+  app.listen(PORT, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Server running at http://localhost:${PORT}`);
+  });
+};
+
+start();

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "bs-fetch": "^0.3.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "reason-react": ">=0.3.4",

--- a/src/UrqlProvider.re
+++ b/src/UrqlProvider.re
@@ -2,7 +2,7 @@
 
 let component = ReasonReact.statelessComponent("Provider");
 
-let make = (~client: UrqlClient.urqlClient, children) =>
+let make = (~client: UrqlClient.client, children) =>
   ReasonReact.wrapJsForReason(
     ~reactClass=provider,
     ~props={"client": client},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,6 +1080,10 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
+bs-fetch@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.0.tgz#60c64457359d0c7e0798d5a04db8987d16c4f8f3"
+
 bs-platform@^3.0.0:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.1.5.tgz#fb34ee4702bc9163848d5537096c4f31ebaeed40"


### PR DESCRIPTION
This PR integrates `bs-fetch` to allow users to pass properly typed `fetchOptions` to their `Client` instance. It also allows users to pass their `fetchOptions` as either an object using the `FetchObj` constructor *or* as a function using the `FetchFn` constructor. It updates the docs and examples to show this new behavior. This should address #10.