### PR TITLE
Add initial test config and tests for Query and Mutation modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ example/build/
 /.graphql_ppx_cache/
 /.vscode/
 /build/
+/coverage/

--- a/__tests__/UrqlMutation_test.re
+++ b/__tests__/UrqlMutation_test.re
@@ -1,0 +1,64 @@
+open Jest;
+open ReasonUrql;
+
+describe("UrqlMutation", () => {
+  describe("UrqlMutation with only query specified", () => {
+    module LikeAllDogs = [%graphql
+      {|
+      mutation likeAllDogs {
+        likeAllDogs {
+          key
+          likes
+        }
+      }
+    |}
+    ];
+
+    let myMutation = Mutation.mutation(LikeAllDogs.make());
+    let expectedMutation = "mutation likeAllDogs  {\nlikeAllDogs  {\nkey  \nlikes  \n}\n\n}\n";
+
+    test("should return a valid urql mutation string", () =>
+      Expect.(
+        expect(myMutation->Mutation.queryGet) |> toEqual(expectedMutation)
+      )
+    );
+
+    test("should return an empty JS object if no variables provided", () =>
+      Expect.(
+        expect(myMutation->Mutation.variablesGet)
+        |> toEqual(Some(Js.Json.object_(Js.Dict.empty())))
+      )
+    );
+  });
+
+  describe("UrqlMutation with variables", () => {
+    module LikeDog = [%graphql
+      {|
+        mutation likeDog($key: ID!) {
+          likeDog(key: $key) {
+            key
+            likes
+          }
+        }
+      |}
+    ];
+
+    let myMutation = Mutation.mutation(LikeDog.make(~key="12345", ()));
+    let expectedMutation = "mutation likeDog($key: ID!)  {\nlikeDog(key: $key)  {\nkey  \nlikes  \n}\n\n}\n";
+    let variables = Js.Dict.empty();
+    Js.Dict.set(variables, "key", Js.Json.string("12345"));
+
+    test("should return a valid urql mutation string", () =>
+      Expect.(
+        expect(myMutation->Mutation.queryGet) |> toEqual(expectedMutation)
+      )
+    );
+
+    test("should return the variables passed to the mutation", () =>
+      Expect.(
+        expect(myMutation->Mutation.variablesGet)
+        |> toEqual(Some(Js.Json.object_(variables)))
+      )
+    );
+  });
+});

--- a/__tests__/UrqlQuery_test.re
+++ b/__tests__/UrqlQuery_test.re
@@ -1,0 +1,60 @@
+open Jest;
+open ReasonUrql;
+
+describe("UrqlQuery", () => {
+  describe("UrqlQuery with only query specified", () => {
+    module TestQuery = [%graphql
+      {|
+        query dogs {
+          dogs {
+            name
+            breed
+            description
+          }
+        }|}
+    ];
+
+    let myQuery = Query.query(TestQuery.make());
+    let expectedQuery = "query dogs  {\ndogs  {\nname  \nbreed  \ndescription  \n}\n\n}\n";
+
+    test("should return a valid urql query string", () =>
+      Expect.(expect(myQuery->Query.queryGet) |> toEqual(expectedQuery))
+    );
+
+    test("should return an empty JS object if no variables provided", () =>
+      Expect.(
+        expect(myQuery->Query.variablesGet)
+        |> toEqual(Some(Js.Json.object_(Js.Dict.empty())))
+      )
+    );
+  });
+
+  describe("UrqlQuery with variables", () => {
+    module TestQuery = [%graphql
+      {|
+        query dog($key: ID!) {
+          dog(key: $key) {
+            name
+            breed
+            description
+          }
+        }|}
+    ];
+
+    let myQuery = Query.query(TestQuery.make(~key="12345", ()));
+    let expectedQuery = "query dog($key: ID!)  {\ndog(key: $key)  {\nname  \nbreed  \ndescription  \n}\n\n}\n";
+    let variables = Js.Dict.empty();
+    Js.Dict.set(variables, "key", Js.Json.string("12345"));
+
+    test("should return a valid urql query string", () =>
+      Expect.(expect(myQuery->Query.queryGet) |> toEqual(expectedQuery))
+    );
+
+    test("should return the variables passed to the query", () =>
+      Expect.(
+        expect(myQuery->Query.variablesGet)
+        |> toEqual(Some(Js.Json.object_(variables)))
+      )
+    );
+  });
+});

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -12,6 +12,10 @@
       "dir": "example",
       "subdirs": true,
       "type": "dev"
+    },
+    {
+      "dir": "__tests__",
+      "type": "dev"
     }
   ],
   "package-specs": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "webpack": "webpack -w",
     "webpack:production": "NODE_ENV=production webpack",
     "start:demo:server": "node example/server/index.js",


### PR DESCRIPTION
This PR begins to address #4, which is in itself a much larger task. Here we add some basic setup for tests using [`bs-jest`](https://github.com/glennsl/bs-jest), and add initial tests for the `Query` and `Mutation` modules. There is some utility in testing that the compiled results of invoking these modules are what we expect them to be, even if we are simply binding to the JS logic itself.

Forthcoming PRs should focus on:

- `Connect`
- `Client`
- `Provider`

and one specifically should add a simple Travis setup for CI. We'll also want to do some research on coverage reporting in Jest so that we can debug the source more easily when needed.