### PR TITLE
Add tests for Connect caching operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # reason-urql
 
-![npm](https://img.shields.io/npm/v/reason-urql.svg?style=flat-square)
-[![Travis (.org)](https://img.shields.io/travis/parkerziegler/reason-urql.svg?style=flat-square)](https://travis-ci.org/parkerziegler/reason-urql)
-[![Coveralls github](https://img.shields.io/coveralls/github/parkerziegler/reason-urql.svg?style=flat-square)](https://coveralls.io/github/parkerziegler/reason-urql?branch=master)
-[![All Contributors](https://img.shields.io/badge/all_contributors-3-blue.svg?style=flat-square)](#contributors)
+![npm](https://img.shields.io/npm/v/reason-urql.svg)
+[![Travis (.org)](https://img.shields.io/travis/parkerziegler/reason-urql.svg)](https://travis-ci.org/parkerziegler/reason-urql)
+[![Coveralls github](https://img.shields.io/coveralls/github/parkerziegler/reason-urql.svg)](https://coveralls.io/github/parkerziegler/reason-urql?branch=master)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-blue.svg)](#contributors)
 
 Reason bindings for Formidable's Universal React Query Library, [`urql`](https://github.com/FormidableLabs/urql).
 

--- a/__tests__/UrqlConnect_test.re
+++ b/__tests__/UrqlConnect_test.re
@@ -89,4 +89,18 @@ describe("Connect", () => {
       },
     );
   });
+
+  describe("cache operations", () => {
+    test("should convert cache operations from a Js.t to a record", () => {
+      let cache = Connect.cacheFromJs(TestUtils.testCacheConnectJs);
+
+      Expect.(expect(cache) |> toEqual(TestUtils.testCacheConnect));
+    });
+
+    test("should convert cache operations as record to a Js.t", () => {
+      let cacheJs = Connect.cacheToJs(TestUtils.testCacheConnect);
+
+      Expect.(expect(cacheJs) |> toEqual(TestUtils.testCacheConnectJs));
+    });
+  });
 });

--- a/__tests__/utils/TestUtils.re
+++ b/__tests__/utils/TestUtils.re
@@ -48,7 +48,7 @@ module TestMutationWithVariable = [%graphql
 ];
 
 /* Simple, no-op cache for tests. */
-/* Mock out cache functions with noops for brevity. */
+/* Mock out cache functions with no-ops for brevity. */
 let write = (~hash as _, ~data as _) =>
   Js.Promise.make((~resolve, ~reject as _) => resolve(. (): 'a));
 
@@ -84,6 +84,35 @@ let testCacheJs: UrqlClient.cacheJs(Js.Dict.t(string), string) = {
   "invalidate": invalidate,
   "invalidateAll": invalidateAll,
   "update": update,
+};
+
+/* Simple, no-op cache functions passed to Connect. */
+/* Mock out cache functions with no-ops for brevity. */
+let readConnect = (~query as _) =>
+  Js.Promise.make((~resolve, ~reject as _) => resolve(. "data"));
+let invalidateConnect = (~query as _: option(UrqlQuery.urqlQuery)=?, ()) =>
+  Js.Promise.make((~resolve, ~reject as _) => resolve(. (): 'a));
+let invalidateAllConnect = () =>
+  Js.Promise.make((~resolve, ~reject as _) => resolve(. (): 'a));
+let updateConnect =
+    (
+      ~callback as
+        _: (~store: Js.Dict.t(string), ~key: string, ~value: string) => unit,
+    ) =>
+  Js.Promise.make((~resolve, ~reject as _) => resolve(. (): 'a));
+
+let testCacheConnect: UrqlConnect.cache(Js.Dict.t(string), string) = {
+  read: readConnect,
+  invalidate: invalidateConnect,
+  invalidateAll: invalidateAllConnect,
+  update: updateConnect,
+};
+
+let testCacheConnectJs: UrqlConnect.cacheJs(Js.Dict.t(string), string) = {
+  "read": readConnect,
+  "invalidate": invalidateConnect,
+  "invalidateAll": invalidateAllConnect,
+  "update": updateConnect,
 };
 
 /* Sample data provided by urql's render prop. */

--- a/src/UrqlConnect.re
+++ b/src/UrqlConnect.re
@@ -36,6 +36,16 @@ type cache('store, 'value) = {
     Js.Promise.t(unit),
 };
 
+type cacheJs('store, 'value) = {
+  .
+  "invalidate": (~query: UrqlQuery.urqlQuery=?, unit) => Js.Promise.t(unit),
+  "invalidateAll": unit => Js.Promise.t(unit),
+  "read": (~query: UrqlQuery.urqlQuery) => Js.Promise.t('value),
+  "update":
+    (~callback: (~store: 'store, ~key: string, ~value: 'value) => unit) =>
+    Js.Promise.t(unit),
+};
+
 /* Arguments passed to the render prop. */
 type renderArgs('data, 'store, 'value) = {
   .


### PR DESCRIPTION
This PR just adds a few tests to ensure the cache operations returned by `urql` to the render prop are properly converted between records and `Js.t` objects. We do expose `cacheToJs` and `cacheFromJs` functions using `[@bs.deriving converter]`, so these tests ensure these are working as expected 🎉

I also fixed a small piece of the API – `invalidate`. The `invalidate` operation accepts a single, optional argument, `~query`. If it receives this argument, it will invalidate that particular query, otherwise it will default to using the query on `Connect`. To properly type a single, optional argument, we needed to pass a final `unit` parameter. See [here](http://2ality.com/2017/12/functions-reasonml.html#with-optional-parameters-you-need-at-least-one-positional-parameter) for more explanation.